### PR TITLE
Upgrade to persistent-mongoDB 2.11.0.0

### DIFF
--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -8,7 +8,7 @@ packages:
   - HDBC-postgresql-2.3.2.7
   - HPDF-1.5.1
   - odd-jobs-0.2.2
-  - persistent-mongoDB-2.11.0.0
+  - persistent-mongoDB-2.10.0.1
   - prolude-0.0.0.6
   - servant-lucid-0.9.0.2
   - servant-serf-0.0.3

--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -8,6 +8,7 @@ packages:
   - HDBC-postgresql-2.3.2.7
   - HPDF-1.5.1
   - odd-jobs-0.2.2
+  - persistent-mongoDB-2.11.0.0
   - prolude-0.0.0.6
   - servant-lucid-0.9.0.2
   - servant-serf-0.0.3
@@ -32,12 +33,6 @@ packages:
   # https://github.com/flipstone/orville/pull/55
   - git: https://github.com/EdutainmentLIVE/orville
     commit: 8a2432891e96a547777b67a67135e235a1dce80c
-
-  # https://github.com/yesodweb/persistent/pull/1129
-  - git: https://github.com/codygman/persistent
-    commit: 71de35824f3592efb6cdb6cfd3fe29bb119008c0
-    subdirs:
-      - persistent-mongoDB
 
   # https://github.com/haskell-servant/servant-blaze/pull/19
   - git: https://github.com/aschmois/servant-blaze


### PR DESCRIPTION
Version 2.10.0.1 incorporates the changes from https://github.com/yesodweb/persistent/pull/1129. Version 2.11.0.0 is the current latest.