### PR TITLE
Upgrade servant-serf to support latest hpack

### DIFF
--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -4,6 +4,7 @@ packages:
   - AesonBson-0.4.0
   - csv-conduit-0.7.2.0
   - direct-daemonize-3.1
+  - generics-eot-0.4.0.1
   - graphula-2.0.0.2
   - HDBC-postgresql-2.4.0.0
   - HPDF-1.5.1

--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -14,7 +14,6 @@ packages:
   - persistent-postgresql-2.11.0.0
   - prolude-0.0.0.14
   - servant-lucid-0.9.0.2
-  - servant-serf-0.0.3
   - servant-static-th-0.2.4.0
   - timing-convenience-0.1
 
@@ -43,3 +42,7 @@ packages:
   # https://github.com/EdutainmentLIVE/recurly
   - git: https://github.com/EdutainmentLIVE/recurly
     commit: caafdaf62918d3d41dc57f1b547507265e1ed002
+    
+  # https://github.com/EdutainmentLIVE/servant-serf/pull/2
+  - git: https://github.com/EdutainmentLIVE/servant-serf
+    commit: 95ab42625a2b464bafc936c1b0f29b8578680e87


### PR DESCRIPTION
Should have been done as part of https://github.com/EdutainmentLIVE/snapshot/pull/22.
Discovered in https://github.com/EdutainmentLIVE/docker-stack-develop/pull/19.
Fixed by https://github.com/EdutainmentLIVE/servant-serf/pull/2. 
