### PR TITLE
Update Prolude

### DIFF
--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -13,7 +13,7 @@ packages:
   - persistent-template-2.9.1.0
   - persistent-mongoDB-2.11.0.0
   - persistent-postgresql-2.11.0.0
-  - prolude-0.0.0.16
+  - prolude-0.0.0.17
   - servant-lucid-0.9.0.2
   - servant-static-th-0.2.4.0
   - timing-convenience-0.1


### PR DESCRIPTION
2021-01-11 is the latest nightly so no update needed there.