### PR TITLE
Upgrade to hashable 1.3.3.0

### DIFF
--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -4,6 +4,7 @@ packages:
   - AesonBson-0.4.0
   - direct-daemonize-3.1
   - evoke-0.2021.8.25
+  - hashable-1.3.3.0
   - HDBC-postgresql-2.5.0.0
   - HPDF-1.5.3
   - odd-jobs-0.2.2


### PR DESCRIPTION
https://app.shortcut.com/itprotv/story/92466/address-hashmap-dos-vulnerability

I missed this in #40 after I downgraded the resolver. We need at least `hashable` 1.3.2.0 to get the new flag. 

---

- [ ] I manually tested the code locally to make sure that it works.
- [ ] If there is documentation, I made sure it's accurate and up to date.
- [ ] If possible, I wrote automated tests for the new behavior.
